### PR TITLE
Remove Modules.override to allow other ServletModules to be installed in the injector

### DIFF
--- a/src/main/java/com/hubspot/dropwizard/guice/GuiceBundle.java
+++ b/src/main/java/com/hubspot/dropwizard/guice/GuiceBundle.java
@@ -26,7 +26,6 @@ public class GuiceBundle<T extends Configuration> implements ConfiguredBundle<T>
 	private final AutoConfig autoConfig;
 	private final List<Module> modules;
 	private Injector injector;
-	private JerseyContainerModule jerseyContainerModule;
 	private DropwizardEnvironmentModule dropwizardEnvironmentModule;
 	private Optional<Class<T>> configurationClass;
 	private GuiceContainer container;
@@ -75,13 +74,13 @@ public class GuiceBundle<T extends Configuration> implements ConfiguredBundle<T>
 	@Override
 	public void initialize(Bootstrap<?> bootstrap) {
 		container = new GuiceContainer();
-		jerseyContainerModule = new JerseyContainerModule(container);
+		JerseyContainerModule jerseyContainerModule = new JerseyContainerModule(container);
 		if (configurationClass.isPresent()) {
 			dropwizardEnvironmentModule = new DropwizardEnvironmentModule<T>(configurationClass.get());
 		} else {
 			dropwizardEnvironmentModule = new DropwizardEnvironmentModule<Configuration>(Configuration.class);
 		}
-		modules.add(Modules.override(new JerseyServletModule()).with(jerseyContainerModule));
+		modules.add(jerseyContainerModule);
 		modules.add(dropwizardEnvironmentModule);
 		injector = Guice.createInjector(modules);
 		if (autoConfig != null) {

--- a/src/main/java/com/hubspot/dropwizard/guice/JerseyContainerModule.java
+++ b/src/main/java/com/hubspot/dropwizard/guice/JerseyContainerModule.java
@@ -1,24 +1,22 @@
 package com.hubspot.dropwizard.guice;
 
-import com.google.inject.AbstractModule;
-import com.google.inject.Provides;
+import com.sun.jersey.guice.JerseyServletModule;
 import com.sun.jersey.spi.container.WebApplication;
 
-public class JerseyContainerModule extends AbstractModule {
+public class JerseyContainerModule extends JerseyServletModule {
+    private final GuiceContainer container;
 
-	private final GuiceContainer container;
+    public JerseyContainerModule(final GuiceContainer container) {
+        this.container = container;
+    }
 
-	public JerseyContainerModule(final GuiceContainer container) {
-		this.container = container;
-	}
+    @Override
+    protected void configureServlets() {
+        bind(GuiceContainer.class).toInstance(container);
+    }
 
-	@Override
-	protected void configure() {
-		bind(GuiceContainer.class).toInstance(container);
-	}
-
-	@Provides
-	public WebApplication webApp() {
-		return container.getWebApplication();
-	}
+    @Override
+    public WebApplication webApp(com.sun.jersey.guice.spi.container.servlet.GuiceContainer guiceContainer) {
+        return container.getWebApplication();
+    }
 }


### PR DESCRIPTION
This is to resolve HubSpot/dropwizard-guice#8

Updated the GuiceBundle and JerseyContainerModule so that JerseyContainerModule no longer relies on Modules.override to swap the Dropwizard WebApplication for the standard Jersey one. Using Modules.override prevents other ServletModules from being installed in the DI container.

Using inheritance probably isn't the most elegant solution, but I've confirmed that it works, and the Dropwizard resource config is correctly being injected.

I've also confirmed that further ServletModules are correctly being added to the injector.
