### PR TITLE
updated namespaces to the latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>com.codahale.dropwizard</groupId>
+			<groupId>io.dropwizard</groupId>
 			<artifactId>dropwizard-core</artifactId>
 			<version>0.7.0-SNAPSHOT</version>
 		</dependency>

--- a/src/main/java/com/hubspot/dropwizard/guice/AutoConfig.java
+++ b/src/main/java/com/hubspot/dropwizard/guice/AutoConfig.java
@@ -1,10 +1,10 @@
 package com.hubspot.dropwizard.guice;
 
-import com.codahale.dropwizard.Bundle;
-import com.codahale.dropwizard.lifecycle.Managed;
-import com.codahale.dropwizard.servlets.tasks.Task;
-import com.codahale.dropwizard.setup.Bootstrap;
-import com.codahale.dropwizard.setup.Environment;
+import io.dropwizard.Bundle;
+import io.dropwizard.lifecycle.Managed;
+import io.dropwizard.servlets.tasks.Task;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
 import com.google.common.base.Preconditions;
 import com.google.inject.Injector;
 import com.sun.jersey.spi.inject.InjectableProvider;

--- a/src/main/java/com/hubspot/dropwizard/guice/DropwizardEnvironmentModule.java
+++ b/src/main/java/com/hubspot/dropwizard/guice/DropwizardEnvironmentModule.java
@@ -1,7 +1,7 @@
 package com.hubspot.dropwizard.guice;
 
-import com.codahale.dropwizard.Configuration;
-import com.codahale.dropwizard.setup.Environment;
+import io.dropwizard.Configuration;
+import io.dropwizard.setup.Environment;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provider;
 import com.google.inject.Provides;

--- a/src/main/java/com/hubspot/dropwizard/guice/GuiceBundle.java
+++ b/src/main/java/com/hubspot/dropwizard/guice/GuiceBundle.java
@@ -1,9 +1,9 @@
 package com.hubspot.dropwizard.guice;
 
-import com.codahale.dropwizard.Configuration;
-import com.codahale.dropwizard.ConfiguredBundle;
-import com.codahale.dropwizard.setup.Bootstrap;
-import com.codahale.dropwizard.setup.Environment;
+import io.dropwizard.Configuration;
+import io.dropwizard.ConfiguredBundle;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;


### PR DESCRIPTION
As dropwizard migrated from "com.codahale" to "io" I guess this project should do the same, because as for now i am unable to use current version with latest dropwizard snapshots from io.dropwizard.
