### PR TITLE
Upgraded Guice to 4.0 and Dropwizard to 0.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Dropwizard `Task` requires a TaskName. Therefore when Auto Configuring a `Task`,
     public class MyTask extends Task {
 
         @Inject
-        protected InjectedTask(@Named("MyTaskName") String name) {
+        protected MyTask(@Named("MyTaskName") String name) {
             super(name);
         }
 
@@ -131,7 +131,7 @@ public class HelloWorldModule extends AbstractModule {
 
 ## Injector Factory
 You can also replace the default Guice `Injector` by implementing your own `InjectorFactory`. For example if you want 
-to use [Governator](https://github.com/Netflix/governator) you can set the following InjectorFactory (using Jav8 Lambda)
+to use [Governator](https://github.com/Netflix/governator), you can set the following InjectorFactory (using Jav8 Lambda)
 when initializing the GuiceBundle:
 
 ```java

--- a/README.md
+++ b/README.md
@@ -1,18 +1,17 @@
-Dropwizard-Guice
-================
+# Dropwizard-Guice
 
 A simple DropWizard extension for integrating Guice via a bundle. It optionally uses classpath 
 scanning courtesy of the Reflections project to discover resources and more to install into 
 the dropwizard environment upon service start.
 
-### Usage
+## Usage
 
 ```xml
     <dependencies>
         <dependency>
             <groupId>com.hubspot.dropwizard</groupId>
             <artifactId>dropwizard-guice</artifactId>
-            <version>0.7.0.2</version>
+            <version>0.8.X</version>
         </dependency>
     </dependencies>
 ```
@@ -51,7 +50,8 @@ public class HelloWorldApplication extends Application<HelloWorldConfiguration> 
 }
 ```
 
-Lastly, you can enable auto configuration via package scanning.
+## Auto Configuration
+You can enable auto configuration via package scanning.
 ```java
 public class HelloWorldApplication extends Application<HelloWorldConfiguration> {
 
@@ -83,6 +83,30 @@ public class HelloWorldApplication extends Application<HelloWorldConfiguration> 
   }
 }
 ```
+
+Dropwizard `Task` requires a TaskName. Therefore when Auto Configuring a `Task`, you need to inject in the TaskName:
+
+    @Singleton
+    public class MyTask extends Task {
+
+        @Inject
+        protected InjectedTask(@Named("MyTaskName") String name) {
+            super(name);
+        }
+
+        @Override
+        public void execute(ImmutableMultimap<String, String> immutableMultimap, PrintWriter printWriter) throws Exception {
+
+        }
+    }
+
+And bind the TaskName in your module:
+
+    bindConstant().annotatedWith(Names.named("MyTaskName")).to("my awesome task");
+
+See the test cases: `InjectedTask` and `TestModule` for more details.
+
+## Environment and Configuration
 If you are having trouble accessing your Configuration or Environment inside a Guice Module, you could try using a provider.
 
 ```java
@@ -105,21 +129,10 @@ public class HelloWorldModule extends AbstractModule {
 }
 ```
 
+## Injector Factory
 You can also replace the default Guice `Injector` by implementing your own `InjectorFactory`. For example if you want 
-to use [Governator](https://github.com/Netflix/governator) you can create the following implementation:
-
-```java
-public class GovernatorInjectorFactory implements InjectorFactory {
-
-  @Override
-  public Injector create( final Stage stage, final List<Module> modules ) {
-    return LifecycleInjector.builder().inStage( stage ).withModules( modules ).build()
-        .createInjector();
-  }
-}
-```
-
-and then set the InjectorFactory when initializing the GuiceBundle:
+to use [Governator](https://github.com/Netflix/governator) you can set the following InjectorFactory (using Jav8 Lambda)
+when initializing the GuiceBundle:
 
 ```java
 @Override
@@ -129,12 +142,18 @@ public void initialize(Bootstrap<HelloWorldConfiguration> bootstrap) {
     .addModule(new HelloWorldModule())
     .enableAutoConfig(getClass().getPackage().getName())
     .setConfigClass(HelloWorldConfiguration.class)
-    .setInjectorFactory( new GovernatorInjectorFactory() )
+    .setInjectorFactory((stage, modules) -> LifecycleInjector.builder()
+        .inStage(stage)
+        .withModules(modules)
+        .build()
+        .createInjector()))
     .build();
 
  bootstrap.addBundle(guiceBundle);
 }
 ```
+
+
 
 Please fork [an example project](https://github.com/eliast/dropwizard-guice-example) if you'd like to get going right away. 
 

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>com.squarespace.jersey2-guice</groupId>
             <artifactId>jersey2-guice</artifactId>
-            <version>0.9</version>
+            <version>0.10</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.glassfish.jersey.containers</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -46,9 +46,8 @@
     </developers>
 
     <properties>
-        <io.dropwizard.version>0.8.0-rc3</io.dropwizard.version>
+        <io.dropwizard.version>0.8.1</io.dropwizard.version>
     </properties>
-
 
     <dependencies>
         <dependency>
@@ -70,7 +69,7 @@
         <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
-            <version>4.0-beta5</version>
+            <version>4.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.guava</groupId>
@@ -81,12 +80,12 @@
         <dependency>
             <groupId>com.google.inject.extensions</groupId>
             <artifactId>guice-servlet</artifactId>
-            <version>4.0-beta5</version>
+            <version>4.0</version>
         </dependency>
         <dependency>
             <groupId>com.squarespace.jersey2-guice</groupId>
             <artifactId>jersey2-guice</artifactId>
-            <version>0.5</version>
+            <version>0.9</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.glassfish.jersey.containers</groupId>


### PR DESCRIPTION
Updated to Guice 4.0 stable release and DW 0.8.1. All tests are passing.

Also updated README:
- change usage version to `0.8.X`
- add section subheadings since documentation is getting longer
- replaced `GovernatorInjectorFactory` example with Java8 lambda
- gave example of Task auto configuration which require TaskName binding.