### PR TITLE
Dropwizard 0.8.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     </developers>
 
     <properties>
-        <dropwizard.version>0.8.1</dropwizard.version>
+        <dropwizard.version>0.8.2</dropwizard.version>
         <dep.guava.version>18.0</dep.guava.version>
         <dep.jetty.version>9.2.9.v20150224</dep.jetty.version>
         <hibernate.version>5.1.3.Final</hibernate.version>
@@ -44,31 +44,37 @@
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
+            <version>${dropwizard.version}</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-jackson</artifactId>
+            <version>${dropwizard.version}</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-jersey</artifactId>
+            <version>${dropwizard.version}</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-jetty</artifactId>
+            <version>${dropwizard.version}</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-lifecycle</artifactId>
+            <version>${dropwizard.version}</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-servlets</artifactId>
+            <version>${dropwizard.version}</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-healthchecks</artifactId>
-            <version>3.1.1</version>
+            <version>3.1.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -93,13 +99,18 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-server</artifactId>
-            <version>2.17</version>
+            <version>2.18</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.glassfish.hk2.external</groupId>
                     <artifactId>javax.inject</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-servlet-core</artifactId>
+            <version>2.18</version>
         </dependency>
         <dependency>
             <groupId>com.squarespace.jersey2-guice</groupId>
@@ -113,6 +124,10 @@
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.containers</groupId>
+                    <artifactId>jersey-container-servlet-core</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.hubspot.dropwizard</groupId>
     <artifactId>dropwizard-guice</artifactId>
-    <version>0.8.1.3-SNAPSHOT</version>
+    <version>0.8.2.0-SNAPSHOT</version>
     <description>Simple library for using Guice DI in a dropwizard service.</description>
     <url>https://github.com/HubSpot/dropwizard-guice</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,12 @@
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-jersey</artifactId>
             <version>${dropwizard.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.glassfish.hk2.external</groupId>
+                    <artifactId>javax.inject</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
@@ -99,18 +105,13 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-server</artifactId>
-            <version>2.18</version>
+            <version>2.19</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.glassfish.hk2.external</groupId>
                     <artifactId>javax.inject</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.containers</groupId>
-            <artifactId>jersey-container-servlet-core</artifactId>
-            <version>2.18</version>
         </dependency>
         <dependency>
             <groupId>com.squarespace.jersey2-guice</groupId>
@@ -157,7 +158,7 @@
         <dependency>
             <groupId>org.glassfish.hk2</groupId>
             <artifactId>hk2-api</artifactId>
-            <version>2.4.0-b10</version>
+            <version>2.4.0-b25</version>
         </dependency>
         <dependency>
             <groupId>javax.ws.rs</groupId>


### PR DESCRIPTION
updated to dropwizard 0.8.2 which uses jersey 2.19
test are passing.
our application works with the snapshot dependency.
