### PR TITLE
#29 - servlet support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,11 @@
+# Jenkinsfile
+# Build and test a Maven project
+
+node {
+  git url: 'https://github.com/mlk/dropwizard-guice.git'
+  def mvnHome = tool 'M3'
+  sh "${mvnHome}/bin/mvn -B -Dmaven.test.failure.ignore verify"
+  step([$class: 'JUnitResultArchiver', testResults:
+'**/target/foobar/TEST-*.xml'])
+}
+

--- a/src/main/java/com/hubspot/dropwizard/guice/ServletPath.java
+++ b/src/main/java/com/hubspot/dropwizard/guice/ServletPath.java
@@ -1,0 +1,12 @@
+package com.hubspot.dropwizard.guice;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ServletPath {
+    String value();
+}

--- a/src/test/java/com/hubspot/dropwizard/guice/AutoConfigTest.java
+++ b/src/test/java/com/hubspot/dropwizard/guice/AutoConfigTest.java
@@ -5,12 +5,14 @@ import com.google.inject.Injector;
 import com.hubspot.dropwizard.guice.objects.*;
 import io.dropwizard.Bundle;
 import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jetty.MutableServletContextHandler;
 import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
 import io.dropwizard.servlets.tasks.Task;
 import io.dropwizard.setup.AdminEnvironment;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
+import org.eclipse.jetty.servlet.ServletHolder;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -81,7 +83,21 @@ public class AutoConfigTest {
     }
 
     @Test
+    public void addServlets() {
+        //given
+        when(environment.getApplicationContext()).thenReturn(mock(MutableServletContextHandler.class));
+
+        //when
+        autoConfig.run(environment, injector);
+
+        //then
+        verify(environment.getApplicationContext()).addServlet(new ServletHolder("/test/servlet", injector.getInstance(InjectedServlet.class)), "/test/servlet");
+    }
+
+    @Test
     public void interfaceResourcesNotAdded() {
+
+
         //when
         autoConfig.run(environment, injector);
 

--- a/src/test/java/com/hubspot/dropwizard/guice/InjectedIntegrationTest.java
+++ b/src/test/java/com/hubspot/dropwizard/guice/InjectedIntegrationTest.java
@@ -68,4 +68,18 @@ public class InjectedIntegrationTest {
         assertThat(message).isEqualTo("this DAO was bound just-in-time");
     }
 
+
+    @Test
+    public void shouldUseServlet() {
+
+        // when
+        final String message = client.target(
+                String.format("http://localhost:%d/test/servlet", RULE.getLocalPort()))
+                .request()
+                .get(String.class);
+
+        // then
+        assertThat(message).isEqualTo("from the servlet");
+    }
+
 }

--- a/src/test/java/com/hubspot/dropwizard/guice/objects/InjectedServlet.java
+++ b/src/test/java/com/hubspot/dropwizard/guice/objects/InjectedServlet.java
@@ -1,0 +1,22 @@
+package com.hubspot.dropwizard.guice.objects;
+
+import com.google.inject.Singleton;
+import com.hubspot.dropwizard.guice.ServletPath;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@ServletPath("/test/servlet")
+@Singleton
+public class InjectedServlet extends HttpServlet {
+
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+            throws ServletException, IOException
+    {
+        resp.getWriter().write("from the servlet");
+        resp.getWriter().close();
+    }
+}

--- a/src/test/java/com/hubspot/dropwizard/guice/objects/NotInjectedServletAsMissingAnnotation.java
+++ b/src/test/java/com/hubspot/dropwizard/guice/objects/NotInjectedServletAsMissingAnnotation.java
@@ -1,0 +1,6 @@
+package com.hubspot.dropwizard.guice.objects;
+
+import javax.servlet.http.HttpServlet;
+
+public class NotInjectedServletAsMissingAnnotation extends HttpServlet {
+}


### PR DESCRIPTION
This implements basic servlet automapping (see #29 ). It uses a new annotation ([`@ServletPath`](https://github.com/mlk/dropwizard-guice/blob/29_servlet_support/src/main/java/com/hubspot/dropwizard/guice/ServletPath.java) on the servlet to state the servlets path. The [`AutoConfig`](https://github.com/mlk/dropwizard-guice/blob/29_servlet_support/src/main/java/com/hubspot/dropwizard/guice/AutoConfig.java) will then magic up the servlets.
