### PR TITLE
fix #89: Use correct url pattern to register the GuiceFilter

### DIFF
--- a/src/main/java/com/hubspot/dropwizard/guice/JerseyUtil.java
+++ b/src/main/java/com/hubspot/dropwizard/guice/JerseyUtil.java
@@ -72,6 +72,6 @@ public class JerseyUtil {
 
   public static void registerGuiceFilter(Environment environment) {
     environment.servlets().addFilter("Guice Filter", GuiceFilter.class)
-           .addMappingForUrlPatterns(null, false, environment.getApplicationContext().getContextPath() + "*");
+           .addMappingForUrlPatterns(null, false, "/*");
   }
 }


### PR DESCRIPTION
Servlet and filter mappings don't need to take the server context path into account, "/*" is sufficient.